### PR TITLE
Multiple options and outputs

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -184,7 +184,7 @@ func (t *Transcoder) validate() error {
 
 	for index, output := range t.output {
 		if output == "" {
-			return errors.New(fmt.Sprintf("output at index %d is an empty string", index))
+			return fmt.Errorf("output at index %d is an empty string", index)
 		}
 	}
 

--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -134,6 +134,11 @@ func (t *Transcoder) WithOptions(opts transcoder.Options) transcoder.Transcoder 
 	return t
 }
 
+func (t *Transcoder) WithAdditionalOptions(opts transcoder.Options) transcoder.Transcoder {
+	t.options = append(t.options, opts.GetStrArguments()...)
+	return t
+}
+
 // validate ...
 func (t *Transcoder) validate() error {
 	if t.config.FfmpegBinPath == "" {

--- a/transcoder.go
+++ b/transcoder.go
@@ -10,4 +10,5 @@ type Transcoder interface {
 	Output(o string) Transcoder
 	OutputPipe(w *io.WriteCloser, r *io.ReadCloser) Transcoder
 	WithOptions(opts Options) Transcoder
+	WithAdditionalOptions(opts Options) Transcoder
 }


### PR DESCRIPTION
For a project I'm working on, I need to be able to transcode to multiple output files, with different options, in one transcoding process.

Here is an example, of how I would expect a ffmpeg call in this context to look
`ffmpeg -i 149336093 -f webm -vf scale=-2:90 -y "./output/90px.webm" -f webm -vf scale=-2:240 -y "./output/240px.webm"`

As this is currently not possible with this library, I tried to implement the changes necessary for that.
The changes include

- Changing the `output` attribute of `Transcoder` to a slice of string
- Changing the `options` attribute of `Transcoder` to a slice of slices of string
- Adding a new function, `withAdditionalOptions`, that appends a new `Options` object to the `options` attribute, instead of overwriting it
- Changing the logic of how the ffmpeg call is built
  - The input file and the options given to `Start(opts)` are appended first
  - After that, if only 1 output file and no additional options were defined, just the output file is appended
  - If there are multiple output files, they are iterated over and appended, along with the options defined at the same index in `t.options` (Which were not being used in the code until now, as I noticed)
  - If there are more elements in the `t.options` slice, than there are output files in `t.output`, the remaining options get squashed together before the last output file
    - This behavior could also be changed to squash surplus options at the beginning of the command, I'm not sure which is better
  - This means, that the assignment of options to output files is dependent on the order, in which you call the methods on the transcoder object
  - Updating the validate function to reflect these changes
    - In particular, validate fails, if you passed more output files than options to the transcoder, as that would not make any sense
    - If you only passed 1 output file with no options it doesn't fail though, as that may be a valid ffmpeg call

These changes proved to run just fine for me in my tests. Here is the piece of code, that I tested them with in my project, it all worked out as expected:

```go
format90 := "mp4"
overwrite90 := true
vf90 := "scale=-2:90"

options90 := &ffmpeg.Options{
	OutputFormat: &format90,
	Overwrite:    &overwrite90,
	VideoFilter:  &vf90,
}

format240 := "webm"
overwrite240 := true
vf240 := "scale=-2:240"

options240 := &ffmpeg.Options{
	OutputFormat: &format240,
	Overwrite:   &overwrite240,
	VideoFilter: &vf240,
}

overwrite := true

startOptions := &ffmpeg.Options{
	Overwrite: &overwrite,
}

ffmpegConfig := &ffmpeg.Config{
	FfmpegBinPath:   "/usr/bin/ffmpeg",
	FfprobeBinPath:  "/usr/bin/ffprobe",
	ProgressEnabled: true,
	//Verbose:         true,
}

progress, err := ffmpeg.
	New(ffmpegConfig).
	Input("/transcoder/test").
	WithAdditionalOptions(options90).
	Output("/transcoder/output/test.90.mp4").
	WithAdditionalOptions(options240).
	Output("/transcoder/output/test.240.webm").
	Start(startOptions)

if err != nil {
	log.Fatal(err)
}

for msg := range progress {
	fmt.Printf("%+v", msg)
}
```

If there are any problems with my PR I'll be happy to fix them. Thank you very much for your work on this library!