### PR TITLE
Enable reading Progress

### DIFF
--- a/ffmpeg/progress.go
+++ b/ffmpeg/progress.go
@@ -8,3 +8,28 @@ type Progress struct {
 	Progress        float64
 	Speed           string
 }
+
+// GetFramesProcessed ...
+func (p Progress) GetFramesProcessed() string {
+	return p.FramesProcessed
+}
+
+// GetCurrentTime ...
+func (p Progress) GetCurrentTime() string {
+	return p.CurrentTime
+}
+
+// GetCurrentBitrate ...
+func (p Progress) GetCurrentBitrate() string {
+	return p.CurrentBitrate
+}
+
+// GetProgress ...
+func (p Progress) GetProgress() float64 {
+	return p.Progress
+}
+
+// GetSpeed ...
+func (p Progress) GetSpeed() string {
+	return p.Speed
+}

--- a/progress.go
+++ b/progress.go
@@ -2,4 +2,9 @@ package transcoder
 
 // Progress ...
 type Progress interface {
+	GetFramesProcessed() string
+	GetCurrentTime() string
+	GetCurrentBitrate() string
+	GetProgress() float64
+	GetSpeed() string
 }


### PR DESCRIPTION
So far you are only able to print out the `Progress` object, that's  sent by the channel returned from `transcoder.Start`. This means, that reading the progress information inside of your program is unnecessarily complex. To combat this, this pull request adds some methods to the Progress interface, to make its fields readable programmatically. 

The changes are:
- Add getters for all relevant fields to the `Progress` interface in package `transcoder`.
- Implement the getters in package `ffmpeg`

I've tested the changes with the following code and found no issues:
```go
progress, err := transcoder.Start(startOptions)

if err != nil {
	log.Fatal(err)
}

for p := range progress {
	fmt.Println(p.GetFramesProcessed(), p.GetCurrentTime(), p.GetCurrentBitrate(), p.GetSpeed(), p.GetProgress())
}
```

This PR should not break any existing behaviour. If there are any problems with it, I'll be happy to fix them