### PR TITLE
Added GitNbChannel function that return number of channels

### DIFF
--- a/ffmpeg/ffmpeg.go
+++ b/ffmpeg/ffmpeg.go
@@ -14,8 +14,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/floostack/transcoder"
-	"github.com/floostack/transcoder/utils"
+	"github.com/sashker/transcoder"
+	"github.com/sashker/transcoder/utils"
 )
 
 // Transcoder ...

--- a/ffmpeg/metadata.go
+++ b/ffmpeg/metadata.go
@@ -29,6 +29,7 @@ type Streams struct {
 	CodecName          string      `json:"codec_name"`
 	CodecLongName      string      `json:"codec_long_name"`
 	Profile            string      `json:"profile"`
+	Channels           int		   `json:"channels"`
 	CodecType          string      `json:"codec_type"`
 	CodecTimeBase      string      `json:"codec_time_base"`
 	CodecTagString     string      `json:"codec_tag_string"`
@@ -165,6 +166,11 @@ func (s Streams) GetCodecLongName() string {
 //GetProfile ...
 func (s Streams) GetProfile() string {
 	return s.Profile
+}
+
+//GetNbChannels returns number of channels for the stream
+func (s Streams) GetNbChannels() int {
+	return s.Channels
 }
 
 //GetCodecType ...

--- a/ffmpeg/metadata.go
+++ b/ffmpeg/metadata.go
@@ -1,6 +1,6 @@
 package ffmpeg
 
-import "github.com/floostack/transcoder"
+import "github.com/sashker/transcoder"
 
 // Metadata ...
 type Metadata struct {

--- a/ffmpeg/options.go
+++ b/ffmpeg/options.go
@@ -65,6 +65,7 @@ type Options struct {
 	PixFmt                *string           `flag:"-pix_fmt"`
 	WhiteListProtocols    []string          `flag:"-protocol_whitelist"`
 	Overwrite             *bool             `flag:"-y"`
+	MapChannel            *string           `flag:"-map_channel"`
 	ExtraArgs             map[string]interface{}
 }
 
@@ -102,7 +103,7 @@ func (opts Options) GetStrArguments() []string {
 					values = append(values, flag, fmt.Sprintf("%v:%v", k, v))
 				}
 			}
-			
+
 			if vi, ok := value.(*int); ok {
 				values = append(values, flag, fmt.Sprintf("%d", *vi))
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/floostack/transcoder
+module github.com/sashker/transcoder
 
 go 1.13

--- a/metadata.go
+++ b/metadata.go
@@ -27,6 +27,7 @@ type Streams interface {
 	GetCodecName() string
 	GetCodecLongName() string
 	GetProfile() string
+	GetNbChannels() int
 	GetCodecType() string
 	GetCodecTimeBase() string
 	GetCodecTagString() string


### PR DESCRIPTION
I'm not sure if it was intentional to leave out the number of channels of a stream but for me, this info is required, so I added it.
Tested with the replacement of the module in my go.mod file.