### PR TITLE
Fixed ExtraArgs feature

### DIFF
--- a/ffmpeg/options.go
+++ b/ffmpeg/options.go
@@ -97,9 +97,9 @@ func (opts Options) GetStrArguments() []string {
 				}
 			}
 
-			if vm, ok := value.(map[string]string); ok {
+			if vm, ok := value.(map[string]interface{}); ok {
 				for k, v := range vm {
-					values = append(values, flag, fmt.Sprintf("%v:%v", k, v))
+					values = append(values, k, fmt.Sprintf("%v", v))
 				}
 			}
 			


### PR DESCRIPTION
`map[string]string` is replaced by `map[string]interface{}`. The map key is used as a flag.