### PR TITLE
feat(context): added WithContext method for Transcoder

### DIFF
--- a/transcoder.go
+++ b/transcoder.go
@@ -1,6 +1,7 @@
 package transcoder
 
 import (
+	"context"
 	"io"
 )
 
@@ -13,5 +14,6 @@ type Transcoder interface {
 	OutputPipe(w *io.WriteCloser, r *io.ReadCloser) Transcoder
 	WithOptions(opts Options) Transcoder
 	WithAdditionalOptions(opts Options) Transcoder
+	WithContext(ctx *context.Context) Transcoder
 	GetMetadata() (Metadata, error)
 }


### PR DESCRIPTION
As mentioned in issue #10, this PR aims to provide users with an easy way to pass in a `context.Context` object to the transcoder.

Transcoder.Start() will now check if a context is set (via WithContext, similarily to how the transcoder is currently configured) and if there is one present it will use `exec.CommandContext` instead of just `exec.Command`. 

Feedback appreciated, hope this helps.